### PR TITLE
Add basic structured metadata to dataset pages

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -29,6 +29,22 @@
 <script src="{{ "js/toc.js" }}"></script>
 <script src="{{ "js/customscripts.js" }}"></script>
 
+{% if page.seo.type == "Dataset" %}
+<script type="application/ld+json">
+{
+"@context": "http://schema.org",
+"@type": "Dataset",
+"name": "{{page.title}}",
+"author": {
+"@type": "Organization",
+"name": "{{page.author}}"
+},
+"description": "{{page.description}}",
+"temporalCoverage": "{{page.date_created}}"
+}
+</script>
+{% endif %}
+
 <link rel="shortcut icon" href="{{ "images/favicon.ico"  }}">
 
 <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -35,7 +35,7 @@
 "@context": "http://schema.org",
 "@type": "Dataset",
 "name": "{{page.title}}",
-"author": {
+"creator": {
 "@type": "Organization",
 "name": "{{page.author}}"
 },

--- a/dc0-chlat-split01-025.md
+++ b/dc0-chlat-split01-025.md
@@ -1,7 +1,7 @@
 ---
 title: "CMB-S4 DC0 CHLAT Split01 025GHz"
 author: "CMB-S4 Collaboration"
-description: "CMB-S4 DC0 CHLAT Split01 025GHz"
+description: "CMB-S4 DC0 CHLAT Split01 025GHz. Simulated maps at 25GHz by the Simons Observatory Large Aperture Telescope in Chile."
 date_created: "2023-03-16"
 seo:
   type: Dataset


### PR DESCRIPTION
This adds minimal JSON-LD to allow for [dataset discovery](https://developers.google.com/search/docs/appearance/structured-data/dataset). This uses the YAML headers in the pages to build the JSON-LD. The page-building scripts will need to be updated to create longer descriptions for each dataset. The pages can be validated using the [rich results tool](https://search.google.com/test/rich-results).